### PR TITLE
Rh/comma is not displayed for single select tokens

### DIFF
--- a/VENTokenField/VENTokenField.m
+++ b/VENTokenField/VENTokenField.m
@@ -98,7 +98,7 @@ static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
     
     // Accessing bare value to avoid kicking off a premature layout run.
     _toLabelText = NSLocalizedString(@"To:", nil);
-
+    [self layoutIfNeeded];
     self.originalHeight = CGRectGetHeight(self.frame);
 
     // Add invisible text field to handle backspace when we don't have a real first responder.

--- a/VENTokenField/VENTokenField.m
+++ b/VENTokenField/VENTokenField.m
@@ -307,7 +307,7 @@ static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
             [weakSelf didTapToken:weakToken];
         };
 
-        [token setTitleText:[NSString stringWithFormat:@"%@,", title]];
+        [token setTitleText:[NSString stringWithFormat:@"%@%@", title, ([self numberOfTokens] == 1 ? @"" : @",")]];
         token.colorScheme = [self colorSchemeForTokenAtIndex:i];
         
         [self.tokens addObject:token];


### PR DESCRIPTION
This PR contains the following changes:
1. Fixes a resizing bug that @navindev fixed
2. When there is only a single VENToken the comma is no longer appended to the end of the tokens.

**Notes**
I will tag a new version and update the pod in develop so all can see the changes.